### PR TITLE
Upgrade grunt-contrib-nodeunit

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt": "~0.4.5",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-jshint": "^0.9.2",
-    "grunt-contrib-nodeunit": "^0.3.3",
+    "grunt-contrib-nodeunit": "^1.0.0",
     "q": "^1.0.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-if",
   "description": "Conditionally run tasks",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "homepage": "https://github.com/tylerbeck/grunt-if",
   "author": {
     "name": "Tyler Beck",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,6 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-jshint": "^0.9.2",
-    "grunt-contrib-nodeunit": "^1.0.0",
     "q": "^1.0.1"
   },
   "peerDependencies": {
@@ -44,6 +40,10 @@
     "dependency"
   ],
   "devDependencies": {
-    "grunt-bump": "^0.3.0"
+    "grunt": "^0.4.5",
+    "grunt-bump": "^0.3.4",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0"
   }
 }


### PR DESCRIPTION
grunt-contrib-nodeunit 0.3.3 depends on request 2.69.1, which has disappeared from npm (https://github.com/npm/npm/issues/13123). This and the other grunt dependencies can also move to devDependencies.
